### PR TITLE
Fix proxy issues

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,11 @@ export default defineConfig({
 	server: {
 		open: true,
 		proxy: {
-			"/api": "CHANGE_ME",
+			"/api": {
+				target: "CHANGE_ME",
+				secure: true,
+				changeOrigin: true,
+			},
 		},
 	},
 });


### PR DESCRIPTION
In working for another project, we had some issues where `FormData` seemed to get lost in a POST request. There is apparently a bug with vite's proxy that reads the body stream, and you cannot consume a stream more than once, so we sent a deflated stream to our backend.

I'm not sure why, but setting these two booleans for every proxy endpoint seems to prevent this from happening.