### PR TITLE
Feat display base UI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,9 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "vite-react-template",
       "dependencies": {
+        "@base-ui/react": "1.0.0",
         "@tanstack/react-query": "5.90.7",
         "@uidotdev/usehooks": "2.4.1",
         "babel-plugin-react-compiler": "1.0.0",
@@ -86,6 +88,10 @@
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
+    "@base-ui/react": ["@base-ui/react@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@base-ui/utils": "0.2.3", "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "tabbable": "^6.3.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-4USBWz++DUSLTuIYpbYkSgy1F9ZmNG9S/lXvlUN6qMK0P0RlW+6eQmDUB4DgZ7HVvtXl4pvi4z5J2fv6Z3+9hg=="],
+
+    "@base-ui/utils": ["@base-ui/utils@0.2.3", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-/CguQ2PDaOzeVOkllQR8nocJ0FFIDqsWIcURsVmm53QGo8NhFNpePjNlyPIB41luxfOqnG7PU0xicMEw3ls7XQ=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.3.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.4", "@biomejs/cli-darwin-x64": "2.3.4", "@biomejs/cli-linux-arm64": "2.3.4", "@biomejs/cli-linux-arm64-musl": "2.3.4", "@biomejs/cli-linux-x64": "2.3.4", "@biomejs/cli-linux-x64-musl": "2.3.4", "@biomejs/cli-win32-arm64": "2.3.4", "@biomejs/cli-win32-x64": "2.3.4" }, "bin": { "biome": "bin/biome" } }, "sha512-TU08LXjBHdy0mEY9APtEtZdNQQijXUDSXR7IK1i45wgoPD5R0muK7s61QcFir6FpOj/RP1+YkPx5QJlycXUU3w=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w40GvlNzLaqmuWYiDU6Ys9FNhJiclngKqcGld3iJIiy2bpJ0Q+8n3haiaC81uTPY/NA0d8Q/I3Z9+ajc14102Q=="],
@@ -155,6 +161,14 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.11", "", { "os": "win32", "cpu": "ia32" }, "sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.11", "", { "os": "win32", "cpu": "x64" }, "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -622,6 +636,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
+
     "reset-css": ["reset-css@5.0.2", "", {}, "sha512-YtgUGSq5z5W0NPSjsBW7ys7rtWa8P8AiE7S6Fg3d1TQCPpAodgYyLuZYlU0AOsLtprk/fC9ormHN/0pAavVIDw=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -661,6 +677,8 @@
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "svg-parser": ["svg-parser@2.0.4", "", {}, "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="],
+
+    "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
+		"@base-ui/react": "1.0.0",
 		"@tanstack/react-query": "5.90.7",
 		"@uidotdev/usehooks": "2.4.1",
 		"babel-plugin-react-compiler": "1.0.0",

--- a/src/components/form/field/field.module.scss
+++ b/src/components/form/field/field.module.scss
@@ -1,0 +1,14 @@
+.field {
+	display: flex;
+	flex-direction: column;
+	gap: var(--unit-2);
+}
+
+.label {
+	font-weight: 600;
+}
+
+.description {
+	color: var(--color-text-secondary);
+	font-size: var(--font-size-small);
+}

--- a/src/components/form/field/field.tsx
+++ b/src/components/form/field/field.tsx
@@ -1,0 +1,62 @@
+import { Field as FieldPrimitive } from "@base-ui/react/field";
+import classNames from "classnames";
+import style from "./field.module.scss";
+
+const Field = ({
+	children,
+	className,
+	...props
+}: FieldPrimitive.Root.Props) => {
+	return (
+		<FieldPrimitive.Root
+			{...props}
+			className={classNames(style.field, className)}
+		>
+			{children}
+		</FieldPrimitive.Root>
+	);
+};
+
+const FieldLabel = ({
+	children,
+	className,
+	...props
+}: FieldPrimitive.Label.Props) => {
+	return (
+		<FieldPrimitive.Label
+			{...props}
+			className={classNames(style.label, className)}
+		>
+			{children}
+		</FieldPrimitive.Label>
+	);
+};
+
+const FieldDescription = ({
+	children,
+	className,
+	...props
+}: FieldPrimitive.Description.Props) => {
+	return (
+		<FieldPrimitive.Description
+			{...props}
+			className={classNames(style.description, className)}
+		>
+			{children}
+		</FieldPrimitive.Description>
+	);
+};
+
+const FieldError = ({
+	children,
+	className,
+	...props
+}: FieldPrimitive.Error.Props) => {
+	return (
+		<FieldPrimitive.Error {...props} className={className}>
+			{children}
+		</FieldPrimitive.Error>
+	);
+};
+
+export { Field, FieldDescription, FieldError, FieldLabel };

--- a/src/components/form/field/index.ts
+++ b/src/components/form/field/index.ts
@@ -1,0 +1,8 @@
+// Because importing component/form/field/field is ugly :)
+
+export {
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldLabel,
+} from "./field";

--- a/src/components/form/field/index.ts
+++ b/src/components/form/field/index.ts
@@ -1,8 +1,0 @@
-// Because importing component/form/field/field is ugly :)
-
-export {
-	Field,
-	FieldDescription,
-	FieldError,
-	FieldLabel,
-} from "./field";

--- a/src/components/form/input/input.tsx
+++ b/src/components/form/input/input.tsx
@@ -1,27 +1,22 @@
+import { Input as InputPrimitive } from "@base-ui/react/input";
 import style from "./input.module.scss";
 
-type Props = React.ComponentPropsWithoutRef<"input"> & {
-	name: string;
-	label?: string;
+type Props = InputPrimitive.Props & {
 	isInvalid?: boolean;
 };
 
 function Input({
-	label,
 	isInvalid,
 	type = "text",
 	...props
 }: Props) {
 	return (
-		<>
-			{label && <span>{label}</span>}
-			<input
-				type={type}
-				aria-invalid={isInvalid}
-				className={style.input}
-				{...props}
-			/>
-		</>
+		<InputPrimitive
+			type={type}
+			aria-invalid={isInvalid}
+			className={style.input}
+			{...props}
+		/>
 	);
 }
 

--- a/src/pages/forgot-password/forgot-password-page.tsx
+++ b/src/pages/forgot-password/forgot-password-page.tsx
@@ -5,6 +5,11 @@ import {
 	Input,
 	Issues,
 } from "components/form";
+import {
+	Field,
+	FieldError,
+	FieldLabel,
+} from "components/form/field/field";
 import { H1 } from "components/heading/heading";
 import { queryClient } from "lib/api";
 import { usePageTitle } from "lib/page-title";
@@ -89,17 +94,19 @@ const ForgotPasswordPage = () => {
 				className={style.form}
 				disabled={isPending}
 			>
-				<label className={style.label} htmlFor="email">
+				<Field name={zorm.fields.email()}>
+					<FieldLabel>{t("forms.fields.email")}</FieldLabel>
 					<Input
-						label={t("forms.fields.email")}
 						name={zorm.fields.email()}
 						id="email"
 						isInvalid={zorm.errors.email(Boolean)}
 					/>
-					{zorm.errors.email((...issues) => (
-						<Issues issues={issues} />
-					))}
-				</label>
+					<FieldError>
+						{zorm.errors.email((...issues) => (
+							<Issues issues={issues} />
+						))}
+					</FieldError>
+				</Field>
 
 				{backendErrors.genericError && (
 					<ErrorText>

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -6,6 +6,11 @@ import {
 	Input,
 	Issues,
 } from "components/form";
+import {
+	Field,
+	FieldError,
+	FieldLabel,
+} from "components/form/field";
 import { H1 } from "components/heading/heading";
 import { queryClient } from "lib/api";
 import { useAuth } from "lib/auth";
@@ -72,30 +77,28 @@ const LoginPage = () => {
 				className={style.form}
 				disabled={isPending}
 			>
-				<label className={style.label} htmlFor="email">
+				<Field name={zorm.fields.email()}>
+					<FieldLabel>{t("forms.fields.email")}</FieldLabel>
+					<Input isInvalid={zorm.errors.email(Boolean)} />
+					<FieldError>
+						{zorm.errors.email((...issues) => (
+							<Issues issues={issues} />
+						))}
+					</FieldError>
+				</Field>
+				<Field name={zorm.fields.password()}>
+					<FieldLabel>
+						{t("forms.fields.password")}
+					</FieldLabel>
 					<Input
-						label={t("forms.fields.email")}
-						isInvalid={zorm.errors.email(Boolean)}
-						name={zorm.fields.email()}
-						id="email"
+						type="password"
+						isInvalid={zorm.errors.password(Boolean)}
 					/>
-					{zorm.errors.email((...issues) => (
-						<Issues issues={issues} />
-					))}
-				</label>
-				<div className={style.label}>
-					<label className={style.label} htmlFor="password">
-						<Input
-							type="password"
-							label={t("forms.fields.password")}
-							isInvalid={zorm.errors.password(Boolean)}
-							name={zorm.fields.password()}
-							id="password"
-						/>
+					<FieldError>
 						{zorm.errors.password((...issues) => (
 							<Issues issues={issues} />
 						))}
-					</label>
+					</FieldError>
 
 					<Link
 						to="/forgot-password"
@@ -103,7 +106,7 @@ const LoginPage = () => {
 					>
 						{t("pages.login.forgotPassword")}
 					</Link>
-				</div>
+				</Field>
 
 				{!!backendErrors.genericError && (
 					<ErrorText>

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -10,7 +10,7 @@ import {
 	Field,
 	FieldError,
 	FieldLabel,
-} from "components/form/field";
+} from "components/form/field/field";
 import { H1 } from "components/heading/heading";
 import { queryClient } from "lib/api";
 import { useAuth } from "lib/auth";

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -6,6 +6,7 @@
 
 body {
 	background-color: white;
+	isolation: isolate;
 	color: black;
 	font: var(--font-body-medium-regular);
 }


### PR DESCRIPTION
## 🎨 Showcase: Base UI Integration for Form Components

### Summary

This PR demonstrates how we can leverage [Base UI](https://base-ui.com/) (`@base-ui/react`) as the foundation for our form components instead of building everything from scratch.

### Why Base UI?

Our current form components (as noted in the README) are **not production-ready** and were only meant as template placeholders. Rather than investing time building our own primitives, Base UI offers:

- **Unstyled, accessible primitives** – Full control over styling while getting accessibility out of the box
- **React 19 compatible** – First-class support for the latest React features
- **Lightweight** – No bloated CSS; we bring our own styles via SCSS modules
- **Headless architecture** – Flexibility to match our design system without fighting component defaults

### What's Included

- Added `@base-ui/react` as a dependency
- Migrated the `Input` component to use Base UI's `Input` primitive
- Added the `Field` component for better form handling
- Other components (`Button`, `Select`, `Field`) remain as reference implementations showing how they could similarly be migrated

### Next Steps

This is a **proof of concept**. If the team is happy with this approach, we can:

1. Migrate remaining form components (`Button`, `Select`, etc.) to Base UI primitives
2. Leverage more complex Base UI components (Dialog, Menu, Tabs, etc.) as needed
3. Remove the custom implementations marked as "not ready for production"

### Related

- 📖 [Base UI Documentation](https://base-ui.com/)
- 📝 See `src/components/form/README.md` for the original TODO