### PR TITLE
Heyapi & zod4: 3 - upgrade zod

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,8 +16,7 @@
         "react-i18next": "16.2.4",
         "react-router": "7.9.5",
         "the-new-css-reset": "1.11.3",
-        "zod": "3.25.76",
-        "zod-i18n-map": "2.27.0",
+        "zod": "4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.4",
@@ -667,9 +666,7 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "zod-i18n-map": ["zod-i18n-map@2.27.0", "", { "peerDependencies": { "i18next": ">=21.3.0", "zod": ">=3.17.0" } }, "sha512-ORu9XpiVh3WDiEUs5Cr9siGgnpeODoBsTIgSD8sQCH9B//f9KowlzqHUEdPYb3vFonaSH8yPvPCOFM4niwp3Sg=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -297,7 +297,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
 

--- a/heyapi.config.ts
+++ b/heyapi.config.ts
@@ -11,10 +11,7 @@ export default defineConfig([
 				name: "@hey-api/sdk",
 				// validator: true, // optional: https://heyapi.dev/openapi-ts/plugins/sdk#validators
 			},
-			{
-				name: "zod",
-				compatibilityVersion: 3, // TODO: very temporary until next PR
-			},
+			"zod",
 		],
 	},
 ]);

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
 		"react-i18next": "16.2.4",
 		"react-router": "7.9.5",
 		"the-new-css-reset": "1.11.3",
-		"zod": "3.25.76",
-		"zod-i18n-map": "2.27.0"
+		"zod": "4.3.6"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.4",

--- a/src/layouts/app/header/app-header.tsx
+++ b/src/layouts/app/header/app-header.tsx
@@ -21,9 +21,10 @@ const AppHeader = () => {
 	const locale = useLocale();
 	const navigate = useNavigate();
 
-	const languageOptions = Object.keys(
-		i18n.options.resources || {},
+	const languageOptions = (
+		i18n.options.supportedLngs as Readonly<string[]>
 	)
+		.filter((lng) => lng !== "cimode")
 		.toSorted((a, b) => a.localeCompare(b, locale))
 		.map((lang) => ({
 			value: lang,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -6,15 +6,12 @@ import {
 	useTranslation,
 } from "react-i18next";
 import { z } from "zod";
-import { zodI18nMap } from "zod-i18n-map";
-import {
-	default as ZodEnUs,
-	default as ZodNlNl,
-} from "zod-i18n-map/locales/nl/zod.json";
+import { en, nl } from "zod/locales";
 
 const LOCALSTORAGE_LOCALE_KEY = "locale";
 const FALLBACK_LNG =
 	localStorage.getItem(LOCALSTORAGE_LOCALE_KEY) ?? "nl-NL";
+const zodLocales = { en, nl };
 
 /**
  * Reads a file path and returns the filename.
@@ -54,10 +51,20 @@ const supportedLanguages = Object.fromEntries(
 		]),
 	),
 );
+const supportedLocales = Object.keys(supportedLanguages);
 
-const supportedLanguageNames = Object.keys(
-	supportedLanguages,
-);
+/**
+ * Switch language of zod default messages
+ * If we ever need to support more then 2 (nl, en) we should spend more time to figure
+ * out how to dynamically import. Spent too much time on this, but no banana.
+ */
+const loadZodLocale = async (locale: string) => {
+	// biome-ignore format: because it gets ugly
+	const lng = locale.substring(0, 2) as keyof typeof zodLocales;
+	if (lng in zodLocales) {
+		z.config(zodLocales[lng]());
+	}
+};
 
 /**
  * Run this once before loading the app so the
@@ -73,22 +80,15 @@ export const init = async () => {
 		)
 		.use(initReactI18next)
 		.init({
-			// Supported and fallback languages are the same
-			supportedLngs: supportedLanguageNames,
+			// Fallback language should be one of supported languages
+			supportedLngs: supportedLocales,
 			fallbackLng: FALLBACK_LNG,
-
-			// Use zod error translations together with backend plugin
-			partialBundledLanguages: true,
-			resources: {
-				"nl-NL": { zod: ZodNlNl },
-				"en-US": { zod: ZodEnUs },
-			},
-
-			// Default to FALLBACK_LNG, even when automatic detection
-			// says otherwise.
+			// Default to FALLBACK_LNG, even when automatic detection says otherwise.
 			lng: FALLBACK_LNG,
 		});
-	z.setErrorMap(zodI18nMap);
+
+	i18n.on("languageChanged", loadZodLocale);
+	loadZodLocale(FALLBACK_LNG);
 };
 
 export default i18n;


### PR DESCRIPTION
> The third PR in a series to upgrade the api generation tool to heyapi and upgrade zod.
> 
> Zod is currently a kind of glue, but NONE of the packages that use zod in this project are updated anymore.  
> Instead of 1 big PR that updates all, to keep it sane I will create multiple smaller PRs.

- Upgrades zod to 4
- Using native zod i18n

To test, add some validation to a component (eg. Home) and change language with the dropdown. Example:

```tsx
	const result = z.string().min(2).safeParse("");

	return (
		<div className={style.page}>
			<H1 size="medium">{t("pages.home.title")}</H1>
			{!result.success &&
				result.error.issues.map((issue) => (
					<ErrorText key={issue.path.join(".")}>
						{issue.message}
					</ErrorText>
				))}
		</div>
	);
```


> Note: ~~I could not get dynamic loading of zod locales to work.~~
> Dynamic loading of locales IS working, but it is not automatically updating, because the `onLanguageChanged` event gets triggered while the react render loop is running. The async loaded zod locale config will be finished too late for it to be part of that render.
