### PR TITLE
format on save in workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "biomejs.biome",
 	"editor.codeActionsOnSave": {
 		"source.organizeImports.biome": "explicit"
@@ -6,7 +7,7 @@
 	"[scss]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
-	"typescript.tsdk": "node_modules\\typescript\\lib",
+	"js/ts.tsdk.path": "node_modules\\typescript\\lib",
 	"search.exclude": {
 		"**.scss.d.ts": true
 	}


### PR DESCRIPTION
as discussed during FE meeting.  
Also note: `typescript.tsdk` was deprecated, replaced by suggestion of vscode.