### PR TITLE
fix: Use correct js/ts sdk path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
 	"[scss]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
-	"js/ts.tsdk.path": "node_modules\\typescript\\lib",
+	"js/ts.tsdk.path": "node_modules/typescript/lib",
 	"search.exclude": {
 		"**.scss.d.ts": true
 	}


### PR DESCRIPTION
By default, we want everyone's VSCode editor to use the installed version of typescript for its diagnostics.

There is a setting called `js/ts.sdk.path` that should take care of this, but when you let vscode automatically configure this on windows, it uses the wrong path syntax.

We have had this setting for a while but it didn't work (ironically, not even on windows either). The reason why we didn't notice before, is that we are quite diligent about keeping ts updated to the latest version, which is what VSCode uses by default.

The solution is simple: use unix delimiters (forward slash).