### PR TITLE
feat: replace message-sniffing retry logic with HttpError

### DIFF
--- a/src/lib/api/api.tsx
+++ b/src/lib/api/api.tsx
@@ -1,6 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 import env from "env";
 import { client } from "./heyapi/client.gen";
+import { HttpError } from "./http-error";
 import { applyMiddleware } from "./middleware";
 
 // Configure generated fetch client
@@ -21,12 +22,8 @@ export const queryClient = new QueryClient({
 			staleTime: 0,
 			gcTime: 5 * 60 * 1000, // 5 minutes
 			retry: (fails, error) => {
-				// TODO: Use interceptor to re-throw as `HttpError`, including the status code. That is way better than message sniffing.
-				if (
-					error.message
-						.toLowerCase()
-						.startsWith("unauthenticated")
-				) {
+				// Never retry client errors — they won't resolve on their own
+				if (error instanceof HttpError && error.isClientError) {
 					return false;
 				}
 				return fails < 3;

--- a/src/lib/api/http-error.ts
+++ b/src/lib/api/http-error.ts
@@ -1,0 +1,26 @@
+export class HttpError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly statusText: string,
+		public readonly url: string,
+	) {
+		super(`HTTP ${status} ${statusText}`);
+		this.name = "HttpError";
+	}
+
+	get isUnauthorized() {
+		return this.status === 401;
+	}
+
+	get isForbidden() {
+		return this.status === 403;
+	}
+
+	get isClientError() {
+		return this.status >= 400 && this.status < 500;
+	}
+
+	get isServerError() {
+		return this.status >= 500;
+	}
+}

--- a/src/lib/api/middleware.ts
+++ b/src/lib/api/middleware.ts
@@ -1,5 +1,6 @@
 import { TOKEN_NAME } from "lib/auth";
 import { client } from "./heyapi/client.gen";
+import { HttpError } from "./http-error";
 
 export const applyMiddleware = () => {
 	/**
@@ -15,5 +16,15 @@ export const applyMiddleware = () => {
 
 		request.headers.set("Authorization", `Bearer ${token}`);
 		return request;
+	});
+
+	/**
+	 * Re-throw non-2xx responses as HttpError so callers can branch on status codes
+	 */
+	client.interceptors.response.use((response) => {
+		if (!response.ok) {
+			throw new HttpError(response.status, response.statusText, response.url);
+		}
+		return response;
 	});
 };


### PR DESCRIPTION
Add an HttpError class that carries the HTTP status code, then wire up a response interceptor to throw it on every non-2xx response. The QueryClient retry predicate now checks `instanceof HttpError && isClientError` instead of scanning the error message string, which was fragile and would silently break if the API ever changed its error wording.