### PR TITLE
set unique localstorage key per project

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { defineConfig, loadEnv } from "vite";
 import https from "vite-plugin-mkcert";
 import svgr from "vite-plugin-svgr";
 import viteTsConfigPaths from "vite-tsconfig-paths";
+import { name } from "./package.json";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -19,6 +20,7 @@ export default defineConfig(({ mode }) => {
 				outdir: "./src/lib/paraglide",
 				strategy: ["url", "localStorage", "baseLocale"],
 				emitTsDeclarations: true,
+				localStorageKey: `${name}-lang`,
 			}),
 			heyApiPlugin({
 				config: {
@@ -33,7 +35,8 @@ export default defineConfig(({ mode }) => {
 						},
 						"zod",
 					],
-				}}),
+				},
+			}),
 			tanstackRouter({
 				autoCodeSplitting: true,
 				quoteStyle: "double",


### PR DESCRIPTION
If this value is not set, every project will get `PARAGLIDE_LOCALE` as LS key for language. Now it is tied to package.json name value, which we can assume to be changed when the project changes. (I hope :D)